### PR TITLE
Stay with the default 8.5.11.3 webapp runner

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ fi
 install_java_with_overlay ${BUILD_DIR}
 
 # Install Webapp Runner
-WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-8.5.51.0}
+WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-8.5.11.3}
 WEBAPP_RUNNER_URL="https://buildpacks-repository.s3.eu-central-1.amazonaws.com/webapp-runner-${WEBAPP_RUNNER_VERSION}.jar"
 curl --retry 3 --silent --location $WEBAPP_RUNNER_URL --output ${BUILD_DIR}/webapp-runner.jar
 


### PR DESCRIPTION
Default version of the webapp runner were updated in #6 but it seems it's not a
good idea: https://app.intercom.io/a/apps/w4oogu7s/inbox/inbox/all/conversations/26009166868

Let's stick with what works.