### PR TITLE
fix: ignore `Procfile` presence or absence

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -9,7 +9,5 @@ config_vars:
   JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
 EOF
 
-if [ ! -f $BUILD_DIR/Procfile ]; then
-    echo "default_process_types:"
-    echo "  web: java \$JAVA_OPTS -jar ./webapp-runner.jar --port \$PORT ./*.war"
-fi
+echo "default_process_types:"
+echo "  web: java \$JAVA_OPTS -jar ./webapp-runner.jar --port \$PORT ./*.war"


### PR DESCRIPTION
Make sure the `bin/release` script passes the default start command for the web container.
The platform will handle the `Procfile` override if necessary.

Fixes #10