### PR TITLE
feat: add support for WAR_PATH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,55 @@
-# WAR Buildpack
+# buildpack: Java WAR
 
 This is a [buildpack](http://doc.scalingo.com/buildpacks) for WAR file.
 
-## How it Works
+## Usage
 
-This buildpack will detect your application as WAR if it has a `*.war` file in
-its root directory. It will download the [Webapp
-Runner](https://github.com/heroku/webapp-runner) from the [Maven
-repository](https://search.maven.org/artifact/com.heroku/webapp-runner) and
-execute a web process with the command `java -jar
-/usr/local/bin/webapp-runner.jar my-app.war`.
+### Detection
 
-## Configuration
+If the `WAR_PATH` environment variable is set, this buildpack checks if a .war
+file exists where `WAR_PATH` points. If the file does actually exist, it is
+used and served as the application. Otherwise, the buildpack fails.
 
-### Choose a JDK
+If `WAR_PATH` is not set, the buildpack falls back to checking if a .war file
+exists at the root of the project and uses it if it does exist.
 
-If you want to specifiy a version of the JDK, just set the environment variable
-`JAVA_VERSION` in your application. You can do that either on the dashboard or
-using our CLI with:
+If you want to use a .war file stored at the root of your application, we
+advise to unset the `WAR_PATH` environment variable and let the platform do its
+magic.
 
-```
-scalingo --app my-app env-set JAVA_VERSION=1.7
-```
+### Deployment Workflow
 
-### Choose a Tomcat Version
+During the *`BUILD`* phase, this buildpack:
 
-You can specify a version of Tomcat by modifying the Webapp Runner version.
-It can be done with the environment variable `WEBAPP_RUNNER_VERSION`. You
-can set it either on the dashboard or using our CLI with:
+1. Downloads and installs the Java Runtime Environment.
+2. Downloads and installs a [webapp-runner](https://github.com/heroku/webapp-runner).
+3. Validates the build.
 
-```
-scalingo --app app-name env-set WEBAPP_RUNNER_VERSION=8.5.11.3
-```
+:tada: This process results into a scalable image, ready to be packaged into a
+container.
 
-## License
+### Environment
 
-Licensed under the MIT License. See LICENSE file.
+The following environment variables are available for you to tweak your
+deployment:
+
+#### `JAVA_VERSION`
+
+Version of the Java Runtime Environment to deploy.\
+Defaults to `17`
+
+#### `JAVA_WEBAPP_RUNNER_VERSION`
+
+Version of the webapp-runner (Tomcat) to install and use.\
+Defaults to `9.0.52.1`
+
+#### `WEBAPP_RUNNER_VERSION`
+
+**Deprecated**, please use [`JAVA_WEBAPP_RUNNER_VERSION`](#java_webapp_runner_version).
+
+#### `WAR_PATH`
+
+Path to the .war file you want to run.\
+When unset, the platform tries to run a .war file at the root of the
+application.\
+Defaults to being unset

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ deployment:
 #### `JAVA_VERSION`
 
 Version of the Java Runtime Environment to deploy.\
-Defaults to `17`
+Defaults to `1.8`
 
 #### `JAVA_WEBAPP_RUNNER_VERSION`
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,38 +1,101 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
-# fail fast
-set -e
+set -eo pipefail
 
-if [[ -n "$BUILDPACK_DEBUG" ]]; then
-  set -x
+if [[ -n "${BUILDPACK_DEBUG}" ]]
+then
+    set -x
 fi
 
-BP_DIR=$(cd $(dirname $0)/..; pwd) # absolute path
-. $BP_DIR/lib/common.sh
+readonly build_dir="${1}"
+readonly cache_dir="${2}"
+env_dir="${3}"
 
-# parse args
-BUILD_DIR=$1
-CACHE_DIR=$2
-ENV_DIR=$3
+readonly java_version="${JAVA_VERSION:-17}"
+readonly webapp_runner_version="${JAVA_WEBAPP_RUNNER_VERSION:-${WEBAPP_RUNNER_VERSION:-9.0.52.1}}"
 
-export_env_dir $ENV_DIR
+readonly base_dir="$( cd -P "$( dirname "$0" )" && pwd )"
+readonly buildpack_dir="$( readlink -f "${base_dir}/.." )"
 
-# Install Java
-JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-"https://buildpacks-repository.s3.eu-central-1.amazonaws.com/jvm-common.tar.xz"}
-mkdir -p /tmp/jvm-common
-curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xJm -C /tmp/jvm-common --strip-components=1
-. /tmp/jvm-common/bin/util
-. /tmp/jvm-common/bin/java
 
-if [[ -n "${JAVA_VERSION}" ]]; then
-  echo "java.runtime.version=${JAVA_VERSION}" > ${BUILD_DIR}/system.properties
-fi
-install_java_with_overlay ${BUILD_DIR}
+source "${buildpack_dir}/lib/common.sh"
 
-# Install Webapp Runner
-WEBAPP_RUNNER_VERSION=${WEBAPP_RUNNER_VERSION:-8.5.11.3}
-WEBAPP_RUNNER_URL="https://buildpacks-repository.s3.eu-central-1.amazonaws.com/webapp-runner-${WEBAPP_RUNNER_VERSION}.jar"
-curl --retry 3 --silent --location $WEBAPP_RUNNER_URL --output ${BUILD_DIR}/webapp-runner.jar
+export_env_dir "${env_dir}"
 
-mkdir -p $CACHE_DIR
+
+# Installs Java and webapp_runner
+#
+# Usage: install_webapp_runner <build_dir> <cache_dir> <java_version> <webapp_runner_version>
+#
+install_webapp_runner() {
+    local jvm_url
+    local runner_url
+
+    local build_d
+    local cache_d
+
+    local tmp_d
+    local jre_version
+    local runner_version
+
+    local cached_jvm_common
+    local cached_runner
+
+    build_d="${1}"
+    cache_d="${2}"
+    jre_version="${3}"
+    runner_version="${4}"
+
+    jvm_url="${JVM_COMMON_BUILDPACK:-"https://buildpacks-repository.s3.eu-central-1.amazonaws.com/jvm-common.tar.xz"}"
+    runner_url="https://buildpacks-repository.s3.eu-central-1.amazonaws.com/webapp-runner-${runner_version}.jar"
+
+    # Install JVM common tools:
+    cached_jvm_common="${cache_d}/jvm-common.tar.xz"
+
+    if [ ! -f "${cached_jvm_common}" ]
+    then
+        curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
+            "${jvm_url}" \
+            --output "${cached_jvm_common}"
+    fi
+
+    tmp_d=$( mktemp -d jvm-common-XXXXXX ) && {
+        tar --extract --xz --touch --strip-components=1 \
+            --file "${cached_jvm_common}" \
+            --directory "${tmp_d}"
+
+        # Source utilities and functions:
+        source "${tmp_d}/bin/util"
+        source "${tmp_d}/bin/java"
+
+        echo "java.runtime.version=${jre_version}" \
+            > "${build_d}/system.properties"
+
+        install_java_with_overlay "${build_d}"
+
+        rm -Rf "${tmp_d}"
+    }
+
+    # Install Webapp Runner
+    cached_runner="${cache_d}/webapp-runner-${runner_version}.jar"
+
+    if [ ! -f "${cached_runner}" ]
+    then
+        curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
+            "${runner_url}" \
+            --output "${cached_runner}" \
+            || {
+                echo "Unable to download webapp runner ${runner_version}. Aborting."
+                exit 1
+            }
+    fi
+
+    cp "${cached_runner}" "${build_d}/webapp-runner.jar"
+}
+
+readonly -f install_webapp_runner
+
+
+install_webapp_runner "${build_dir}" "${cache_dir}" \
+    "${java_version}" "${webapp_runner_version}"

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ readonly build_dir="${1}"
 readonly cache_dir="${2}"
 env_dir="${3}"
 
-readonly java_version="${JAVA_VERSION:-17}"
+readonly java_version="${JAVA_VERSION:-1.8}"
 readonly webapp_runner_version="${JAVA_WEBAPP_RUNNER_VERSION:-${WEBAPP_RUNNER_VERSION:-9.0.52.1}}"
 
 readonly base_dir="$( cd -P "$( dirname "$0" )" && pwd )"

--- a/bin/detect
+++ b/bin/detect
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-BUILD_DIR=$1
+build_dir="${1}"
 
-if [[ -n "$(find $BUILD_DIR -name *.war -type f)" ]]; then
-  echo "WAR"
-  exit 0
+if [ -n "${WAR_PATH}" ]
+then
+    if [ -f "${build_dir}/${WAR_PATH}" ]
+    then
+        echo "WAR"
+        exit 0
+    fi
+else
+    if [ -n "$( find "${build_dir}" -maxdepth 1 -name "*.war" -type f )" ]
+    then
+        echo "WAR"
+        exit 0
+    fi
 fi
 
 echo "no"

--- a/bin/detect
+++ b/bin/detect
@@ -3,7 +3,11 @@
 
 build_dir="${1}"
 
-if [ -n "${WAR_PATH}" ]
+if [[ -n "${WAR_PATH}" && -f "${build_dir}/${WAR_PATH}" ]] ; then
+   [...]
+elif [ -n "$( find "${build_dir}" -maxdepth 1 -name "*.war" -type f )" ] ; then
+  [...]
+fi
 then
     if [ -f "${build_dir}/${WAR_PATH}" ]
     then

--- a/bin/detect
+++ b/bin/detect
@@ -4,22 +4,11 @@
 build_dir="${1}"
 
 if [[ -n "${WAR_PATH}" && -f "${build_dir}/${WAR_PATH}" ]] ; then
-   [...]
+    echo "WAR"
+    exit 0
 elif [ -n "$( find "${build_dir}" -maxdepth 1 -name "*.war" -type f )" ] ; then
-  [...]
-fi
-then
-    if [ -f "${build_dir}/${WAR_PATH}" ]
-    then
-        echo "WAR"
-        exit 0
-    fi
-else
-    if [ -n "$( find "${build_dir}" -maxdepth 1 -name "*.war" -type f )" ]
-    then
-        echo "WAR"
-        exit 0
-    fi
+    echo "WAR"
+    exit 0
 fi
 
 echo "no"

--- a/bin/release
+++ b/bin/release
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-BUILD_DIR=$1
-
 cat <<EOF
 ---
 config_vars:
   JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
+default_process_types:
 EOF
 
-echo "default_process_types:"
-echo "  web: java \$JAVA_OPTS -jar ./webapp-runner.jar --port \$PORT ./*.war"
+if [ -n "${WAR_PATH}" ]
+then
+    echo "  web: java \${JAVA_OPTS} -jar ./webapp-runner.jar --port \${PORT} \"\${WAR_PATH}\""
+else
+    echo "  web: java \${JAVA_OPTS} -jar ./webapp-runner.jar --port \${PORT} ./*.war"
+fi


### PR DESCRIPTION
Add support for a new `WAR_PATH` environment variable that allows users to specify where the .war file to run is stored. This is useful when the .war file is not stored at the root of the project.

Also downloads JVM common tools to cache, and use the cached version if it's available (current version of the buildpack doesn't use the cache).

I'm also suggesting to rename `WEBAPP_RUNNER_VERSION` to `JAVA_WEBAPP_RUNNER_VERSION`. The code still supports `WEBAPP_RUNNER_VERSION`.

> **Important**
> Also updates the default values for:
> - `JAVA_VERSION`: from `1.8` to `17`
> - `WEBAPP_RUNNER_VERSION`: from `8.5.11.3` to `9.0.52.1`

The README file has been updated consequently.