### PR TITLE
docs(compile): more logs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,9 +3,8 @@
 
 set -eo pipefail
 
-if [[ -n "${BUILDPACK_DEBUG}" ]]
-then
-    set -x
+if [[ -n "${BUILDPACK_DEBUG}" ]]; then
+  set -x
 fi
 
 readonly build_dir="${1}"
@@ -29,71 +28,70 @@ export_env_dir "${env_dir}"
 # Usage: install_webapp_runner <build_dir> <cache_dir> <java_version> <webapp_runner_version>
 #
 install_webapp_runner() {
-    local jvm_url
-    local runner_url
+  local jvm_url
+  local runner_url
 
-    local build_d
-    local cache_d
+  local build_d
+  local cache_d
 
-    local tmp_d
-    local jre_version
-    local runner_version
+  local tmp_d
+  local jre_version
+  local runner_version
 
-    local cached_jvm_common
-    local cached_runner
+  local cached_jvm_common
+  local cached_runner
 
-    build_d="${1}"
-    cache_d="${2}"
-    jre_version="${3}"
-    runner_version="${4}"
+  build_d="${1}"
+  cache_d="${2}"
+  jre_version="${3}"
+  runner_version="${4}"
 
-    local buildpacks_repository_url="https://buildpacks-repository.s3.eu-central-1.amazonaws.com"
+  local buildpacks_repository_url="https://buildpacks-repository.s3.eu-central-1.amazonaws.com"
 
-    jvm_url="${JVM_COMMON_BUILDPACK:-"${buildpacks_repository_url}/jvm-common.tar.xz"}"
-    runner_url="${buildpacks_repository_url}/webapp-runner-${runner_version}.jar"
+  jvm_url="${JVM_COMMON_BUILDPACK:-"${buildpacks_repository_url}/jvm-common.tar.xz"}"
+  runner_url="${buildpacks_repository_url}/webapp-runner-${runner_version}.jar"
 
-    # Install JVM common tools:
-    cached_jvm_common="${cache_d}/jvm-common.tar.xz"
+  # Install JVM common tools:
+  cached_jvm_common="${cache_d}/jvm-common.tar.xz"
 
-    if [ ! -f "${cached_jvm_common}" ]
-    then
-        curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
-            "${jvm_url}" \
-            --output "${cached_jvm_common}"
-    fi
+  if [ ! -f "${cached_jvm_common}" ]
+  then
+    curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
+        "${jvm_url}" \
+        --output "${cached_jvm_common}"
+  fi
 
-    tmp_d=$( mktemp -d jvm-common-XXXXXX ) && {
-        tar --extract --xz --touch --strip-components=1 \
-            --file "${cached_jvm_common}" \
-            --directory "${tmp_d}"
+  tmp_d=$( mktemp -d jvm-common-XXXXXX ) && {
+    tar --extract --xz --touch --strip-components=1 \
+        --file "${cached_jvm_common}" \
+        --directory "${tmp_d}"
 
-        # Source utilities and functions:
-        source "${tmp_d}/bin/util"
-        source "${tmp_d}/bin/java"
+    # Source utilities and functions:
+    source "${tmp_d}/bin/util"
+    source "${tmp_d}/bin/java"
 
-        echo "java.runtime.version=${jre_version}" \
-            > "${build_d}/system.properties"
+    echo "java.runtime.version=${jre_version}" \
+        > "${build_d}/system.properties"
 
-        install_java_with_overlay "${build_d}"
+    install_java_with_overlay "${build_d}"
 
-        rm -Rf "${tmp_d}"
-    }
+    rm -Rf "${tmp_d}"
+  }
 
-    # Install Webapp Runner
-    cached_runner="${cache_d}/webapp-runner-${runner_version}.jar"
+  # Install Webapp Runner
+  cached_runner="${cache_d}/webapp-runner-${runner_version}.jar"
 
-    if [ ! -f "${cached_runner}" ]
-    then
-        curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
-            "${runner_url}" \
-            --output "${cached_runner}" \
-            || {
-                echo "Unable to download webapp runner ${runner_version}. Aborting."
-                exit 1
-            }
-    fi
+  if [ ! -f "${cached_runner}" ]; then
+    curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
+        "${runner_url}" \
+        --output "${cached_runner}" \
+        || {
+            echo "Unable to download webapp runner ${runner_version}. Aborting."
+            exit 1
+        }
+  fi
 
-    cp "${cached_runner}" "${build_d}/webapp-runner.jar"
+  cp "${cached_runner}" "${build_d}/webapp-runner.jar"
 }
 
 readonly -f install_webapp_runner

--- a/bin/compile
+++ b/bin/compile
@@ -51,6 +51,8 @@ install_webapp_runner() {
   jvm_url="${JVM_COMMON_BUILDPACK:-"${buildpacks_repository_url}/jvm-common.tar.xz"}"
   runner_url="${buildpacks_repository_url}/webapp-runner-${runner_version}.jar"
 
+  echo "-----> Installing Webapp Runner ${runner_version}..."
+
   # Install JVM common tools:
   cached_jvm_common="${cache_d}/jvm-common.tar.xz"
 
@@ -80,15 +82,18 @@ install_webapp_runner() {
 
   # Install Webapp Runner
   cached_runner="${cache_d}/webapp-runner-${runner_version}.jar"
-
   if [ ! -f "${cached_runner}" ]; then
+    echo "-----> Downloading webapp runner"
+
     curl --location --silent --retry 6 --retry-connrefused --retry-delay 0 \
         "${runner_url}" \
         --output "${cached_runner}" \
         || {
-            echo "Unable to download webapp runner ${runner_version}. Aborting."
+            echo "Unable to download webapp runner ${runner_version}. Aborting." >&2
             exit 1
         }
+  else
+    echo "-----> Got webapp runner from the cache"
   fi
 
   cp "${cached_runner}" "${build_d}/webapp-runner.jar"


### PR DESCRIPTION
So that at least it displays the webapp runner version

```
 emichon@biniou  ~/Downloads  scalingo --app biniou deploy --war ~/Downloads/geoserver.war
-----> Deploying WAR archive: /home/emichon/Downloads/geoserver.war
-----> Uploading archive…
-----> Your deployment has been queued and is going to start…
[LOG] <-- Start deployment of biniou -->
[LOG] Fetching source code
[LOG] Fetching deployment cache
[LOG] -----> Cloning custom buildpack: https://github.com/Scalingo/java-war-buildpack#fix/verbosity
[LOG] -----> Installing Webapp Runner 9.0.68.1...
[LOG] -----> Installing OpenJDK 1.8... done
[LOG] -----> Got webapp runner from the cache
[STATUS] New status: pushing
```